### PR TITLE
Add pinpoint-web helm chart

### DIFF
--- a/pinpoint/charts/pinpoint-web/Chart.yaml
+++ b/pinpoint/charts/pinpoint-web/Chart.yaml
@@ -5,4 +5,6 @@ type: application
 # chart version. 
 version: 0.1.0
 # version number of the application being deployed. 
-appVersion: 2.0.4
+appVersion: 2.1.0
+keywords:
+    - web

--- a/pinpoint/charts/pinpoint-web/templates/_helpers.tpl
+++ b/pinpoint/charts/pinpoint-web/templates/_helpers.tpl
@@ -1,0 +1,88 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pinpoint-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pinpoint-web.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pinpoint-web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pinpoint-web.labels" -}}
+helm.sh/chart: {{ include "pinpoint-web.chart" . }}
+{{ include "pinpoint-web.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pinpoint-web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pinpoint-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "pinpoint-web"
+{{- end }}
+
+{{/*
+Create Mysql Username
+*/}}
+{{- define "pinpoint-web.mysql.username" -}}
+{{- default "admin" .Values.mysql.user -}}
+{{- end }}
+
+{{/*
+Create Mysql Password 
+*/}}
+{{- define "pinpoint-web.mysql.password" -}}
+{{- default "admin" .Values.mysql.password -}}
+{{- end }}
+
+{{/*
+Create Mysql Database for Pinpoint
+*/}}
+{{- define "pinpoint-web.mysql.database" -}}
+{{- default "pinpoint" .Values.mysql.database -}}
+{{- end }}
+
+{{/*
+Create a fully qualified mysql url
+*/}}
+{{- define "pinpoint-web.mysql.url" -}}
+{{- $host :=  default "pinpoint-mysql" .Values.mysql.host }}
+{{- $port :=  default 3306 .Values.mysql.port | int }}
+{{- printf "jdbc:mysql://%s:%d/%s?characterEncoding=UTF-8" $host $port (include "pinpoint-web.mysql.database" .) }}
+{{- end }}
+
+{{/*
+Create Zookeeper address
+*/}}
+{{- define "pinpoint-web.zookeeper.address" -}}
+{{- default "pinpoint-zookeeper" .Values.zookeeper.host -}}
+{{- end }}

--- a/pinpoint/charts/pinpoint-web/templates/configmap.yaml
+++ b/pinpoint/charts/pinpoint-web/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pinpoint-web.fullname" . }}
+  labels:
+{{ include "pinpoint-web.labels" . | indent 4 }}
+data:
+  SPRING_PROFILES_ACTIVE: "{{ .Values.profiles }}"
+  SERVER_PORT: "{{ .Values.serverPort }}"
+  PINPOINT_ZOOKEEPER_ADDRESS: "{{ include "pinpoint-web.zookeeper.address" . }}"
+  CLUSTER_ENABLE: "{{ .Values.clusterEnable }}"
+  CONFIG_SENDUSAGE: "{{ .Values.sendUsage }}"
+  LOGGING_LEVEL_ROOT: "{{ .Values.loggingLevelRoot }}"
+  CONFIG_SHOW_APPLICATIONSTAT: "{{ .Values.showApplicationStat }}"
+  BATCH_ENABLE: "{{ .Values.batch.enable }}"
+  BATCH_SERVER_IP: "{{ .Values.batch.server }}"
+  BATCH_FILNK_SERVER: "{{ .Values.batch.flink }}"
+  JDBC_DRIVERCLASSNAME: "com.mysql.jdbc.Driver"
+  JDBC_URL: "{{ include "pinpoint-web.mysql.url" .}}"
+  ALARM_MAIL_SERVER_URL: "{{ .Values.mail.server.url }}"
+  ALARM_MAIL_SERVER_PORT: "{{ .Values.mail.server.port }}"
+  ALARM_MAIL_SENDER_ADDRESS: "{{ .Values.mail.sender }}"
+  ALARM_MAIL_TRANSPORT_PROTOCOL: "{{ .Values.mail.transportProtocol }}"
+  ALARM_MAIL_SMTP_PORT: "{{ .Values.mail.smtp.port }}"
+  ALARM_MAIL_SMTP_AUTH: "{{ .Values.mail.smtp.auth }}"
+  ALARM_MAIL_SMTP_STARTTLS_ENABLE: "{{ .Values.mail.smtp.startTls.enable }}"
+  ALARM_MAIL_SMTP_STARTTLS_REQUIRED: "{{ .Values.mail.smtp.startTls.required }}"
+  ALARM_MAIL_DEBUG: "{{ .Values.mail.debug }}"

--- a/pinpoint/charts/pinpoint-web/templates/deployment.yaml
+++ b/pinpoint/charts/pinpoint-web/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "pinpoint-web.fullname" . }}
+  labels:
+{{ include "pinpoint-web.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "pinpoint-web.selectorLabels" . | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "pinpoint-web.labels" . | indent 8 }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+      {{- range $key, $value := .Values.podAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+    spec:
+      initContainers:
+       - name: wait-mysql
+         image: alpine
+         command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 pinpoint-mysql 3306 && exit 0 || sleep 3; done; exit 1"]
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: ui
+              containerPort: {{ .Values.serverPort }}
+              protocol: TCP
+          envFrom:
+          - configMapRef:
+              name: {{ template "pinpoint-web.fullname" . }}
+          - secretRef:
+              name: {{ template "pinpoint-web.fullname" . }}
+          livenessProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: {{ .Values.serverPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: {{ .Values.serverPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+{{- with .Values.affinity }}
+      affinity:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}

--- a/pinpoint/charts/pinpoint-web/templates/secret.yaml
+++ b/pinpoint/charts/pinpoint-web/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "pinpoint-web.fullname" . }}
+  labels:
+{{ include "pinpoint-web.labels" . | indent 4 }}
+type: Opaque
+data:
+  ADMIN_PASSWORD: {{ .Values.adminPassword | b64enc | quote }}
+  JDBC_USERNAME: {{ include "pinpoint-web.mysql.username" . | b64enc | quote }}
+  JDBC_PASSWORD: {{ include "pinpoint-web.mysql.password" . | b64enc | quote }}
+  ALARM_MAIL_SERVER_USERNAME: {{ .Values.mail.server.username | b64enc | quote }}
+  ALARM_MAIL_SERVER_PASSWORD: {{ .Values.mail.server.password | b64enc | quote }}

--- a/pinpoint/charts/pinpoint-web/templates/ui-service.yaml
+++ b/pinpoint/charts/pinpoint-web/templates/ui-service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.podAnnotations }}
+  {{- range $key, $value := .Values.podAnnotations }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  name: {{ include "pinpoint-web.fullname" . }}-ui
+  labels:
+{{ include "pinpoint-web.labels" . | indent 4 }}
+spec:
+  ports:
+    - name: ui
+      port: {{ default 8080 .Values.service.ui.port }}
+      protocol: TCP
+      targetPort: {{default 8080 .Values.serverPort }}
+
+{{- if eq "NodePort" .Values.service.ui.type }}
+  {{- if .Values.service.ui.nodePort }}
+      nodePort:  {{ .Values.service.ui.nodePort }}
+  {{- end }}
+{{- end }}
+
+{{- if eq "ClusterIP" .Values.service.ui.type }}
+  {{- if .Values.service.ui.clusterIP }}
+  clusterIP:  {{ .Values.service.ui.clusterIP }}
+  {{- end }}
+{{- end }}
+
+  selector:
+{{ include "pinpoint-web.selectorLabels" . | indent 6 }}
+  type: "{{ .Values.service.ui.type }}"
+{{- if eq "LoadBalancer" .Values.service.ui.type }}
+  {{- if .Values.service.ui.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.ui.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.service.ui.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.service.ui.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/pinpoint/charts/pinpoint-web/values.yaml
+++ b/pinpoint/charts/pinpoint-web/values.yaml
@@ -1,0 +1,62 @@
+replicaCount: 1
+
+imagePullPolicy: Always
+## Annotations to be added to Pinpoint Web pods
+##
+podAnnotations: {}
+## Pod affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Node tolerations for node-exporter scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []
+  # - key: "key"
+  #   operator: "Equal|Exists"
+  #   value: "value"
+  #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+# Configuration for web UI service
+service:
+  ui:
+    type: "LoadBalancer"
+    nodePort:
+    clusterIp:
+    port: 8080
+
+# Configuration for Docker Image 
+image:
+  repository: pinpointdocker/pinpoint-web
+  tag: 2.1.0
+
+profiles: release, batch
+serverPort: 8079
+clusterEnable: false
+
+adminPassword: admin
+sendUsage: false
+loggingLevelRoot: INFO
+showApplicationStat: true
+
+batch:
+  enable: false
+  server: 127.0.0.1
+  flink: 127.0.0.1
+
+mail:
+  server:
+    url: smtp.gmail.com
+    port: 587
+    username: username
+    password: password
+  sender: pinpoint_operator@pinpoint.com
+  transportProtocol: smtp
+  debug: false
+  smtp:
+    port: 25
+    auth: false
+    startTls:
+      enable: false
+      required: false

--- a/pinpoint/values.yaml
+++ b/pinpoint/values.yaml
@@ -24,3 +24,22 @@ mysql:
   # initializationFiles:     
   #   extra_init.sql: |-
   #     CREATE TABLE ...
+
+pinpoint-web:
+  ### If you want to use external MySQL or other settings that are different from default values, fill these fields.
+  ### When the field is empty, it applies the default value.
+  ### Default Value
+  ###   mysql.host : pinpoint-mysql
+  ###   mysql.port : 3306
+  ###   mysql.user : admin
+  ###   mysql.password : admin
+  mysql:
+    host: 
+    port: 
+    user: 
+    password: 
+    database: 
+  
+  ### External zookeeper address (Default : pinpoint-zookeeper) 
+  zookeeper: 
+    host:


### PR DESCRIPTION
Add pinpoint-web helm chart



### Run
1. Fill the `zookeeper.host` field with external zookeeper. 
2. Run `helm install pinpoint pinpoint/`
<details>
<summary>values.yaml</summary>

```yaml
pinpoint-web:
  ### If you want to use external MySQL or other settings that are different from default values, fill these fields.
  ### When the field is empty, it applies the default value.
  ### Default Value
  ###   mysql.host : pinpoint-mysql
  ###   mysql.port : 3306
  ###   mysql.user : admin
  ###   mysql.password : admin
  mysql:
    host: 
    port: 
    user: 
    password: 
    database: 
  
  ### External zookeeper address (Default : pinpoint-zookeeper) 
  zookeeper: 
    host:
```
</details>


