### PR TITLE
fix: Init container missing name

### DIFF
--- a/templates/telegraf.yaml
+++ b/templates/telegraf.yaml
@@ -39,6 +39,7 @@ spec:
               done
 
               echo "✓ Collector is ready!"        - name: download-telegraf-config
+        - name: download-pinpoint-telegraf-configuration
           image: curlimages/curl:7.85.0
           env:
             - name: COLLECTOR_SERVICE_NAME


### PR DESCRIPTION
Hello, I found a small bug on telegraf.yaml file.