### PR TITLE
chore: Add .helmignore to exclude unnecessary files from Helm package

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,15 @@
+# Files and folders that will not be included when creating the Helm package
+
+# Exclude the folder containing the images
+docs/
+
+# Unnecessary system and IDE files
+.git/
+.gitignore
+.idea/
+.vscode/
+.DS_Store
+
+# To lighten the package, documentation files (Optional but recommended)
+README.md
+LICENSE


### PR DESCRIPTION
### Description
This PR addresses the installation failure caused by the Kubernetes Secret size limit (`Secret is invalid: data: Too long > 1MB`).

The issue arises because the `docs/` folder (containing screenshots) is currently included in the Helm chart package, causing the release secret to exceed the allow limit.

### Changes
Added a `.helmignore` file to exclude unnecessary files from the package, specifically:
- `docs/` directory
- `.git/` and VCS files
- IDE configurations

This significantly reduces the chart package size and resolves the deployment error.

Fixes #29