### PR TITLE
[#35] fix: Update Telegraf init container to wait for gRPC port 9991 instead of Thrift 9994

### DIFF
--- a/templates/telegraf.yaml
+++ b/templates/telegraf.yaml
@@ -30,10 +30,10 @@ spec:
             - '-c'
             - |
               echo "Waiting for Collector service to be ready..."
-              echo "Target: ${COLLECTOR_SERVICE_NAME}:9994"
+              echo "Target: ${COLLECTOR_SERVICE_NAME}:9991"
 
-              # Wait for Collector thrift receiver port 9994
-              until nc -z -w5 ${COLLECTOR_SERVICE_NAME} 9994; do
+              # Wait for Collector thrift receiver port 9991
+              until nc -z -w5 ${COLLECTOR_SERVICE_NAME} 9991; do
                 echo "Telegraf is waiting for Collector..."
                 sleep 5
               done


### PR DESCRIPTION
## Description
This PR fixes an issue where the Telegraf pod gets stuck in the `Init` state because it waits for the legacy Thrift port (9994), which is disabled by default in Pinpoint 3.x when the `metric` profile is active.

## Related Issue
Fixes #35

## Changes
- Updated `templates/telegraf.yaml`: Changed the `wait-for-collector` init container command to check the **gRPC Agent port (9991)** instead of the Thrift port (9994).

## Motivation
In the default configuration for this chart (Pinpoint 3.x with `global.metric.enabled: true`), the Collector only listens on gRPC ports (9991, 9992, 9993) and keeps the legacy Thrift receiver (9994) closed. The previous health check was hardcoded to wait for port 9994, causing the deployment to hang indefinitely.

Since the gRPC Agent port (9991) is the primary communication channel for agents in v3, it is a reliable indicator that the Collector is ready.

## Verification
- Verified locally that `pinpoint-collector` listens on ports 9991-9993 but NOT on 9994 when deployed with default values.
- Confirmed that the Telegraf init container hangs when waiting for port 9994.
- This change ensures Telegraf proceeds once the Collector is actually ready on port 9991.