### PR TITLE
[#38] Support for External/Optional Data Sources in Web and Batch Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Deploys Batch and Flink modules for traditional APM processing.
 | `global.metric.enabled` | Enable metric profile deployment | `true` |
 | `global.pinpointVersion` | Pinpoint version | `"3.0.3"` |
 | `global.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `global.datasource.enabled` | Enable global datasource configuration<br/>- Defaults to the MySQL chart dependency | `true` |
+| `global.datasource.driverClassName` | JDBC driver class name<br/>- Defaults to the MySQL driver from the chart dependency | `""` |
+| `global.datasource.jdbcUrl` | JDBC URL for external database<br/>- Defaults to the MySQL service from the chart dependency | `""` |
+| `global.datasource.username` | Database username<br/>- Defaults to the MySQL username from the chart dependency | `""` |
+| `global.datasource.passwordSecret.name` | Secret name containing password | `""` |
+| `global.datasource.passwordSecret.key` | Key in the Secret containing the password | `""` |
+| `global.datasource.password` | Database password (Not RECOMMENDED for production)<br/>- Defaults to the MySQL password from the chart dependency | `""` |
 
 ## Accessing Pinpoint
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Deploys Batch and Flink modules for traditional APM processing.
 | `global.metric.enabled` | Enable metric profile deployment | `true` |
 | `global.pinpointVersion` | Pinpoint version | `"3.0.3"` |
 | `global.image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `global.datasource.enabled` | Enable global datasource configuration<br/>- Defaults to the MySQL chart dependency | `true` |
+| `global.datasource.enabled` | Enable global datasource configuration<br/>- `true` (default): Injects datasource env vars. Defaults to the bundled MySQL if `mysql.enabled` is true.<br/>- `false`: No datasource env vars are injected into Web/Batch. | `true` |
 | `global.datasource.driverClassName` | JDBC driver class name<br/>- Defaults to the MySQL driver from the chart dependency | `""` |
 | `global.datasource.jdbcUrl` | JDBC URL for external database<br/>- Defaults to the MySQL service from the chart dependency | `""` |
 | `global.datasource.username` | Database username<br/>- Defaults to the MySQL username from the chart dependency | `""` |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -58,3 +58,70 @@ Image registry
 {{- printf "%s/" .Values.global.image.registry }}
 {{- end }}
 {{- end }}
+
+{{/*
+Web datasource JDBC URL
+When mysql.enabled is false, you must provide web.datasource.jdbcUrl
+*/}}
+{{- define "pinpoint.web.datasource.jdbcUrl" -}}
+{{- if .Values.web.datasource.jdbcUrl -}}
+{{- .Values.web.datasource.jdbcUrl -}}
+{{- else if .Values.mysql.enabled -}}
+{{- printf "jdbc:mysql://%s-mysql:3306/%s?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true" .Release.Name .Values.mysql.auth.database -}}
+{{- else -}}
+{{- fail "web.datasource.jdbcUrl is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Web datasource username
+When mysql.enabled is false, you must provide web.datasource.username
+*/}}
+{{- define "pinpoint.web.datasource.username" -}}
+{{- if .Values.web.datasource.username -}}
+{{- .Values.web.datasource.username -}}
+{{- else if .Values.mysql.enabled -}}
+{{- .Values.mysql.auth.username -}}
+{{- else -}}
+{{- fail "web.datasource.username is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Web datasource driver class name
+*/}}
+{{- define "pinpoint.web.datasource.driverClassName" -}}
+{{- if .Values.web.datasource.driverClassName -}}
+{{- .Values.web.datasource.driverClassName -}}
+{{- else -}}
+com.mysql.cj.jdbc.Driver
+{{- end -}}
+{{- end -}}
+
+{{/*
+Web datasource password - returns either custom value or secret reference
+When mysql.enabled is false, you must provide either web.datasource.passwordSecret or web.datasource.password
+*/}}
+{{- define "pinpoint.web.datasource.password" -}}
+{{- if .Values.web.datasource.passwordSecret -}}
+{{- if not .Values.web.datasource.passwordSecret.name -}}
+{{- fail "web.datasource.passwordSecret.name is required when passwordSecret is provided" -}}
+{{- end -}}
+{{- if not .Values.web.datasource.passwordSecret.key -}}
+{{- fail "web.datasource.passwordSecret.key is required when passwordSecret is provided" -}}
+{{- end -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ .Values.web.datasource.passwordSecret.name }}
+    key: {{ .Values.web.datasource.passwordSecret.key }}
+{{- else if .Values.web.datasource.password -}}
+value: {{ .Values.web.datasource.password | quote }}
+{{- else if .Values.mysql.enabled -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ .Release.Name }}-mysql
+    key: mysql-password
+{{- else -}}
+{{- fail "web.datasource.password or web.datasource.passwordSecret is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -107,12 +107,9 @@ datasource password - returns either custom value or secret reference
 - When mysql.enabled is false, you must provide either global.datasource.passwordSecret or global.datasource.password
 */}}
 {{- define "pinpoint.datasource.password" -}}
-{{- if .Values.global.datasource.passwordSecret -}}
-{{- if not .Values.global.datasource.passwordSecret.name -}}
-{{- fail "global.datasource.passwordSecret.name is required when passwordSecret is provided" -}}
-{{- end -}}
+{{- if and .Values.global.datasource.passwordSecret .Values.global.datasource.passwordSecret.name -}}
 {{- if not .Values.global.datasource.passwordSecret.key -}}
-{{- fail "global.datasource.passwordSecret.key is required when passwordSecret is provided" -}}
+{{- fail "global.datasource.passwordSecret.key is required when passwordSecret.name is provided" -}}
 {{- end -}}
 valueFrom:
   secretKeyRef:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -107,7 +107,13 @@ datasource password - returns either custom value or secret reference
 - When mysql.enabled is false, you must provide either global.datasource.passwordSecret or global.datasource.password
 */}}
 {{- define "pinpoint.datasource.password" -}}
-{{- if and .Values.global.datasource.passwordSecret .Values.global.datasource.passwordSecret.name -}}
+{{- if and .Values.global.datasource.passwordSecret (or .Values.global.datasource.passwordSecret.name .Values.global.datasource.passwordSecret.key) -}}
+{{- if .Values.global.datasource.password -}}
+{{- fail "Configuration conflict: Both 'global.datasource.password' and 'global.datasource.passwordSecret' are set. Please use only one authentication method." }}
+{{- end -}}
+{{- if not .Values.global.datasource.passwordSecret.name -}}
+{{- fail "global.datasource.passwordSecret.name is required when passwordSecret.key is provided" -}}
+{{- end -}}
 {{- if not .Values.global.datasource.passwordSecret.key -}}
 {{- fail "global.datasource.passwordSecret.key is required when passwordSecret.name is provided" -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -67,8 +67,10 @@ datasource JDBC URL
 {{- define "pinpoint.datasource.jdbcUrl" -}}
 {{- if .Values.global.datasource.jdbcUrl -}}
 {{- .Values.global.datasource.jdbcUrl -}}
-{{- else if .Values.mysql.enabled -}}
+{{- else if and .Values.mysql.enabled .Values.mysql.auth.database -}}
 {{- printf "jdbc:mysql://%s-mysql:3306/%s?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true" .Release.Name .Values.mysql.auth.database -}}
+{{- else if .Values.mysql.enabled -}}
+{{- fail "mysql.auth.database is required when mysql.enabled is true and global.datasource.jdbcUrl is not set" -}}
 {{- else -}}
 {{- fail "global.datasource.jdbcUrl is required when mysql.enabled is false" -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -60,68 +60,72 @@ Image registry
 {{- end }}
 
 {{/*
-Web datasource JDBC URL
-When mysql.enabled is false, you must provide web.datasource.jdbcUrl
+datasource JDBC URL
+- used by Web and Batch components
+- When mysql.enabled is false, you must provide global.datasource.jdbcUrl
 */}}
-{{- define "pinpoint.web.datasource.jdbcUrl" -}}
-{{- if .Values.web.datasource.jdbcUrl -}}
-{{- .Values.web.datasource.jdbcUrl -}}
+{{- define "pinpoint.datasource.jdbcUrl" -}}
+{{- if .Values.global.datasource.jdbcUrl -}}
+{{- .Values.global.datasource.jdbcUrl -}}
 {{- else if .Values.mysql.enabled -}}
 {{- printf "jdbc:mysql://%s-mysql:3306/%s?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true" .Release.Name .Values.mysql.auth.database -}}
 {{- else -}}
-{{- fail "web.datasource.jdbcUrl is required when mysql.enabled is false" -}}
+{{- fail "global.datasource.jdbcUrl is required when mysql.enabled is false" -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Web datasource username
-When mysql.enabled is false, you must provide web.datasource.username
+datasource username
+- used by Web and Batch components
+- When mysql.enabled is false, you must provide global.datasource.username
 */}}
-{{- define "pinpoint.web.datasource.username" -}}
-{{- if .Values.web.datasource.username -}}
-{{- .Values.web.datasource.username -}}
+{{- define "pinpoint.datasource.username" -}}
+{{- if .Values.global.datasource.username -}}
+{{- .Values.global.datasource.username -}}
 {{- else if .Values.mysql.enabled -}}
 {{- .Values.mysql.auth.username -}}
 {{- else -}}
-{{- fail "web.datasource.username is required when mysql.enabled is false" -}}
+{{- fail "global.datasource.username is required when mysql.enabled is false" -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Web datasource driver class name
+datasource driver class name
+- used by Web and Batch components
 */}}
-{{- define "pinpoint.web.datasource.driverClassName" -}}
-{{- if .Values.web.datasource.driverClassName -}}
-{{- .Values.web.datasource.driverClassName -}}
+{{- define "pinpoint.datasource.driverClassName" -}}
+{{- if .Values.global.datasource.driverClassName -}}
+{{- .Values.global.datasource.driverClassName -}}
 {{- else -}}
 com.mysql.cj.jdbc.Driver
 {{- end -}}
 {{- end -}}
 
 {{/*
-Web datasource password - returns either custom value or secret reference
-When mysql.enabled is false, you must provide either web.datasource.passwordSecret or web.datasource.password
+datasource password - returns either custom value or secret reference
+- used by Web and Batch components
+- When mysql.enabled is false, you must provide either global.datasource.passwordSecret or global.datasource.password
 */}}
-{{- define "pinpoint.web.datasource.password" -}}
-{{- if .Values.web.datasource.passwordSecret -}}
-{{- if not .Values.web.datasource.passwordSecret.name -}}
-{{- fail "web.datasource.passwordSecret.name is required when passwordSecret is provided" -}}
+{{- define "pinpoint.datasource.password" -}}
+{{- if .Values.global.datasource.passwordSecret -}}
+{{- if not .Values.global.datasource.passwordSecret.name -}}
+{{- fail "global.datasource.passwordSecret.name is required when passwordSecret is provided" -}}
 {{- end -}}
-{{- if not .Values.web.datasource.passwordSecret.key -}}
-{{- fail "web.datasource.passwordSecret.key is required when passwordSecret is provided" -}}
+{{- if not .Values.global.datasource.passwordSecret.key -}}
+{{- fail "global.datasource.passwordSecret.key is required when passwordSecret is provided" -}}
 {{- end -}}
 valueFrom:
   secretKeyRef:
-    name: {{ .Values.web.datasource.passwordSecret.name }}
-    key: {{ .Values.web.datasource.passwordSecret.key }}
-{{- else if .Values.web.datasource.password -}}
-value: {{ .Values.web.datasource.password | quote }}
+    name: {{ .Values.global.datasource.passwordSecret.name }}
+    key: {{ .Values.global.datasource.passwordSecret.key }}
+{{- else if .Values.global.datasource.password -}}
+value: {{ .Values.global.datasource.password | quote }}
 {{- else if .Values.mysql.enabled -}}
 valueFrom:
   secretKeyRef:
     name: {{ .Release.Name }}-mysql
     key: mysql-password
 {{- else -}}
-{{- fail "web.datasource.password or web.datasource.passwordSecret is required when mysql.enabled is false" -}}
+{{- fail "global.datasource.password or global.datasource.passwordSecret is required when mysql.enabled is false" -}}
 {{- end -}}
 {{- end -}}

--- a/templates/batch.yaml
+++ b/templates/batch.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.batch.enabled (not .Values.global.metric.enabled) .Values.global.datasource.enabled }}
+{{- if and .Values.batch.enabled (not .Values.global.metric.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,6 +69,7 @@ spec:
             - name: BATCH_FLINK_SERVER
               value: "{{ .Release.Name }}-flink-jobmanager:8081"
             # JDBC Configuration - Primary Datasource
+            {{- if .Values.global.datasource.enabled }}
             - name: JDBC_DRIVERCLASSNAME
               value: {{ include "pinpoint.datasource.driverClassName" . | quote }}
             - name: JDBC_URL
@@ -91,6 +92,7 @@ spec:
               value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_PASSWORD
               {{ include "pinpoint.datasource.password" . | nindent 14 }}
+            {{- end }}
             # Mail Configuration for Alarms
             {{- if and .Values.batch.mail.enabled .Values.batch.mail.host }}
             - name: ALARM_MAIL_SERVER_URL

--- a/templates/batch.yaml
+++ b/templates/batch.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.batch.enabled (not .Values.global.metric.enabled) }}
+{{- if and .Values.batch.enabled (not .Values.global.metric.enabled) .Values.global.datasource.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,36 +70,27 @@ spec:
               value: "{{ .Release.Name }}-flink-jobmanager:8081"
             # JDBC Configuration - Primary Datasource
             - name: JDBC_DRIVERCLASSNAME
-              value: "com.mysql.cj.jdbc.Driver"
+              value: {{ include "pinpoint.datasource.driverClassName" . | quote }}
             - name: JDBC_URL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: JDBC_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: JDBC_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
             # Spring Datasource Configuration
             - name: SPRING_DATASOURCE_HIKARI_JDBCURL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
             # Spring Metadata Datasource Configuration
             - name: SPRING_METADATASOURCE_HIKARI_JDBCURL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
             # Mail Configuration for Alarms
             {{- if and .Values.batch.mail.enabled .Values.batch.mail.host }}
             - name: ALARM_MAIL_SERVER_URL

--- a/templates/web.yaml
+++ b/templates/web.yaml
@@ -23,7 +23,7 @@ spec:
         - name: wait-for-zookeeper
           image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
           command: ['sh', '-c', 'until nc -z -w3 {{ include "pinpoint.fullname" . }}-zookeeper 2181; do echo "Web is waiting for Zookeeper..."; sleep 2; done;']
-
+        {{- if .Values.mysql.enabled }}
         - name: wait-for-mysql
           image: "{{ include "pinpoint.imageRegistry" . }}{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
           env:
@@ -41,6 +41,7 @@ spec:
                 sleep 2
               done
               echo "Web Pod: MySQL is ready."
+        {{- end }}
 
         {{- if .Values.hbase.enabled }}
         - name: wait-for-hbase
@@ -87,15 +88,15 @@ spec:
               value: {{ .Values.web.config.springProfiles | quote }}
               {{- end }}
 
+            # MySQL Connection Settings
+            {{- if .Values.web.datasource.enabled }}
             - name: SPRING_DATASOURCE_HIKARI_JDBC_URL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.web.datasource.username" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
+            {{- end }}
 
             # HBase Connection Settings
             {{- if .Values.hbase.enabled }}
@@ -154,28 +155,26 @@ spec:
               value: "true"
             - name: CONFIG_SHOW_APPLICATIONSTAT
               value: "true"
+            {{- if .Values.web.datasource.enabled }}
             - name: JDBC_DRIVERCLASSNAME
-              value: "com.mysql.cj.jdbc.Driver"
+              value: {{ include "pinpoint.web.datasource.driverClassName" . | quote }}
             - name: JDBC_URL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
             - name: JDBC_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.web.datasource.username" . | quote }}
             - name: JDBC_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
+            {{- end }}
 
             # Metadata Source Configuration
+            {{- if .Values.web.datasource.enabled }}
             - name: SPRING_METADATASOURCE_HIKARI_JDBCURL
-              value: "jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true"
+              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_USERNAME
-              value: "{{ .Values.mysql.auth.username }}"
+              value: {{ include "pinpoint.web.datasource.username" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
+              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
+            {{- end }}
 
             # Security Configuration
             - name: PINPOINT_MODULES_WEB_LOGIN

--- a/templates/web.yaml
+++ b/templates/web.yaml
@@ -89,13 +89,13 @@ spec:
               {{- end }}
 
             # MySQL Connection Settings
-            {{- if .Values.web.datasource.enabled }}
+            {{- if .Values.global.datasource.enabled }}
             - name: SPRING_DATASOURCE_HIKARI_JDBC_URL
-              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_USERNAME
-              value: {{ include "pinpoint.web.datasource.username" . | quote }}
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: SPRING_DATASOURCE_HIKARI_PASSWORD
-              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
             {{- end }}
 
             # HBase Connection Settings
@@ -155,25 +155,23 @@ spec:
               value: "true"
             - name: CONFIG_SHOW_APPLICATIONSTAT
               value: "true"
-            {{- if .Values.web.datasource.enabled }}
+            {{- if .Values.global.datasource.enabled }}
             - name: JDBC_DRIVERCLASSNAME
-              value: {{ include "pinpoint.web.datasource.driverClassName" . | quote }}
+              value: {{ include "pinpoint.datasource.driverClassName" . | quote }}
             - name: JDBC_URL
-              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: JDBC_USERNAME
-              value: {{ include "pinpoint.web.datasource.username" . | quote }}
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: JDBC_PASSWORD
-              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
-            {{- end }}
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
 
             # Metadata Source Configuration
-            {{- if .Values.web.datasource.enabled }}
             - name: SPRING_METADATASOURCE_HIKARI_JDBCURL
-              value: {{ include "pinpoint.web.datasource.jdbcUrl" . | quote }}
+              value: {{ include "pinpoint.datasource.jdbcUrl" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_USERNAME
-              value: {{ include "pinpoint.web.datasource.username" . | quote }}
+              value: {{ include "pinpoint.datasource.username" . | quote }}
             - name: SPRING_METADATASOURCE_HIKARI_PASSWORD
-              {{ include "pinpoint.web.datasource.password" . | nindent 14 }}
+              {{ include "pinpoint.datasource.password" . | nindent 14 }}
             {{- end }}
 
             # Security Configuration

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,23 @@ web:
     #   - secretName: pinpoint-tls
     #     hosts:
     #       - pinpoint.yourdomain.com
+  datasource:
+    # Set to false if Web component should not use any datasource
+    # When mysql.enabled is false, you must provide custom jdbcUrl/username/password or passwordSecret
+    enabled: true
+    # Leave empty to use bundled MySQL settings from mysql.auth
+    # Override these values when using external database
+    driverClassName: ""  # Defaults to "com.mysql.cj.jdbc.Driver"
+    jdbcUrl: ""  # Defaults to bundled MySQL: "jdbc:mysql://<release-name>-mysql:3306/<database>?..."
+    username: ""  # Defaults to mysql.auth.username
+    
+    # Password configuration (choose one):
+    # Option 1 (RECOMMENDED): Reference existing Secret
+    # passwordSecret: 
+    #   name: "my-external-db-secret"
+    #   key: "password"
+    # Option 2: Plain text password (NOT RECOMMENDED for production)
+    password: ""  # Defaults to mysql.auth.password (from secret)
 
 # HBase - Primary data storage for trace and performance data
 hbase:

--- a/values.yaml
+++ b/values.yaml
@@ -40,11 +40,13 @@ global:
     username: ""
     # Option 1: Reference existing Secret
     # (RECOMMENDED for production)
+    # NOTE: Mutually exclusive with `password` below. If both are configured,
+    # the chart templates will use `passwordSecret` and ignore `password`.
     # passwordSecret:
     #   name: ""
     #   key: ""
     # Option 2: Plain text password
-    # (NOT RECOMMENDED for production)
+    # (NOT RECOMMENDED for production; do not set this if using `passwordSecret`)
     password: ""
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -74,7 +74,7 @@ web:
     #       - pinpoint.yourdomain.com
   datasource:
     # Set to false if Web component should not use any datasource
-    # When mysql.enabled is false, you must provide custom jdbcUrl/username/password or passwordSecret
+    # When datasource.enabled is true and mysql.enabled is false, you must provide custom jdbcUrl/username/password or passwordSecret
     enabled: true
     # Leave empty to use bundled MySQL settings from mysql.auth
     # Override these values when using external database

--- a/values.yaml
+++ b/values.yaml
@@ -27,10 +27,14 @@ global:
   metric:
     enabled: true  # DEFAULT: Modern mode for new deployments
   # Global Datasource Configuration (Shared by Web and Batch)
-  # When `mysql.enabled` is false but you want to use the external database, you must provide these settings
-  # (used by Web and Batch components when `datasource.enabled` is true)
+  # This configuration controls how Web and Batch components connect to the MySQL database.
   datasource:
-    # Set to false if Web and Batch components should not use any datasource
+    # Enable datasource configuration injection for Web and Batch components.
+    # - true (default): Injects datasource environment variables (JDBC URL, username, password).
+    #   If `mysql.enabled` is true, it automatically connects to the bundled MySQL service.
+    #   If `mysql.enabled` is false, it uses the external configuration provided below.
+    # - false: Does NOT inject any datasource environment variables. Use this only if you do not need
+    #   a relational database connection or are configuring it via custom means.
     enabled: true
     # Defaults to "com.mysql.cj.jdbc.Driver"
     driverClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,27 @@ global:
   # metric.enabled: false = Classic stack (Batch + Flink + traditional processing)
   metric:
     enabled: true  # DEFAULT: Modern mode for new deployments
+  # Global Datasource Configuration (Shared by Web and Batch)
+  # When `mysql.enabled` is false but you want to use the external database, you must provide these settings
+  # (used by Web and Batch components when `datasource.enabled` is true)
+  datasource:
+    # Set to false if Web and Batch components should not use any datasource
+    enabled: true
+    # Defaults to "com.mysql.cj.jdbc.Driver"
+    driverClassName: ""
+    # Required if mysql.enabled is false but you want to use the external database
+    jdbcUrl: ""
+    # Required if mysql.enabled is false but you want to use the external database
+    username: ""
+    # Option 1: Reference existing Secret
+    # (RECOMMENDED for production)
+    # passwordSecret:
+    #   name: ""
+    #   key: ""
+    # Option 2: Plain text password
+    # (NOT RECOMMENDED for production)
+    password: ""
+
 
 # ========================================================================
 # Pinpoint Component Configurations
@@ -72,23 +93,6 @@ web:
     #   - secretName: pinpoint-tls
     #     hosts:
     #       - pinpoint.yourdomain.com
-  datasource:
-    # Set to false if Web component should not use any datasource
-    # When datasource.enabled is true and mysql.enabled is false, you must provide custom jdbcUrl/username/password or passwordSecret
-    enabled: true
-    # Leave empty to use bundled MySQL settings from mysql.auth
-    # Override these values when using external database
-    driverClassName: ""  # Defaults to "com.mysql.cj.jdbc.Driver"
-    jdbcUrl: ""  # Defaults to bundled MySQL: "jdbc:mysql://<release-name>-mysql:3306/<database>?..."
-    username: ""  # Defaults to mysql.auth.username
-    
-    # Password configuration (choose one):
-    # Option 1 (RECOMMENDED): Reference existing Secret
-    # passwordSecret: 
-    #   name: "my-external-db-secret"
-    #   key: "password"
-    # Option 2: Plain text password (NOT RECOMMENDED for production)
-    password: ""  # Defaults to mysql.auth.password (from secret)
 
 # HBase - Primary data storage for trace and performance data
 hbase:
@@ -305,6 +309,10 @@ agent:
 # ========================================================================
 
 # MySQL - Primary database for web interface and batch jobs
+# NOTE: When mysql.enabled is false (using external database):
+#   1. You must configure global.datasource.* settings with your external DB connection info
+#   2. The init-job-mysql will NOT run, so you must manually initialize the database schema
+#   3. Schema SQL files can be found at: https://github.com/pinpoint-apm/pinpoint/tree/master/web/src/main/resources/sql
 mysql:
   enabled: true
   image:


### PR DESCRIPTION
## Description
This PR enhances the Pinpoint Helm chart to support external data sources (e.g., AWS RDS, standalone MySQL) for both Web and Batch components. It centralizes the datasource configuration under the global scope, allowing shared configuration and deployment without the bundled `bitnami/mysql` chart.

## Related Issue
- #38

## Changes

### 1. `values.yaml` Updates
- Introduced `global.datasource` section to allow custom JDBC URL, username, and password configuration shared by Web and Batch components.
- Supports providing the password via both Kubernetes Secrets (`passwordSecret`) and plain text (`password`).

### 2. Template Updates (`web.yaml`, `batch.yaml`)
- Updated both Web and Batch deployments to use the shared `global.datasource` configuration.
- The `wait-for-mysql` init-container is conditional on `.Values.mysql.enabled`.
- Replaced hardcoded JDBC settings with helper templates to inject environment variables dynamically.

### 3. `templates/_helpers.tpl` Additions
- Added helper templates to resolve JDBC URL and credentials globally (`pinpoint.datasource.*`):
  - Defaults to bundled MySQL settings if external configuration is missing.
  - Validates that required fields are present when `mysql.enabled` is false.

## Design Decisions

### Reason for using `global.datasource`
Instead of adding a simple flag like `mysql.external.enabled` or keeping component-specific configurations (like `web.datasource`), we introduced the `global.datasource` configuration block for the following reasons:

1.  **Shared Dependency & Consistency**: Both Web and Batch components require connection to the same MySQL database. Defining the connection details in one global scope avoids duplication and ensures consistency across components.

2.  **Comprehensive Control**: This structure groups all connection details (URL, driver, credentials) and the toggle (`enabled`) in one place, rather than scattering external configurations.

3.  **Decoupling from Bundled Chart**: It allows the Pinpoint cluster to define its datasource connection independently, completely decoupling it from the bundled `mysql` chart regardless of whether it is enabled or disabled.

## Configuration Examples

Here are the common configuration scenarios using `values.yaml`:

### Case 1: Default (Bundled MySQL)
Use the internal MySQL chart provided by the Helm dependency. This is the default behavior.

```yaml
mysql:
  enabled: true

global:
  datasource:
    enabled: true
    # No extra configuration needed; it auto-discovers the bundled MySQL service.
```

### Case 2: External MySQL (Using Secret)
Disable the internal MySQL and connect to an external database using an existing Kubernetes Secret for the password (Recommended).

```yaml
mysql:
  enabled: false

global:
  datasource:
    enabled: true
    driverClassName: "com.mysql.cj.jdbc.Driver"
    jdbcUrl: "jdbc:mysql://mypinpointdb:3306/pinpoint"
    username: "admin"
    passwordSecret:
      name: "pinpoint-db-secret"
      key: "db-password"
```

### Case 3: External MySQL (Using Plain Text Password)
Disable the internal MySQL and connect to an external database using a plain text password directly in `values.yaml`.

```yaml
mysql:
  enabled: false

global:
  datasource:
    enabled: true
    driverClassName: "com.mysql.cj.jdbc.Driver"
    jdbcUrl: "jdbc:mysql://mypinpointdb:3306/pinpoint"
    username: "admin"
    password: "my-secret-password"
```

### Case 4: No Database
Run the components without any JDBC datasource connection (e.g., for specific testing scenarios).

```yaml
mysql:
  enabled: false

global:
  datasource:
    enabled: false
```
