### PR TITLE
fix(web): render ingress configuration correctly

### DIFF
--- a/templates/web.yaml
+++ b/templates/web.yaml
@@ -214,17 +214,32 @@ metadata:
   name: {{ include "pinpoint.fullname" . }}-web
   labels:
     {{- include "pinpoint.labels" . | nindent 4 }}
+  {{- with .Values.web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with .Values.web.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.web.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-    - host: {{ .Values.web.ingress.host }}
+    {{- range .Values.web.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .Values.web.ingress.path }}
-            pathType: ImplementationSpecific
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "pinpoint.fullname" . }}-web
+                name: {{ include "pinpoint.fullname" $ }}-web
                 port:
                   name: http
+          {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -89,6 +89,10 @@ web:
   ingress:
     enabled: false  # Enable for production external access
     ingressClassName: "nginx"
+    annotations: {}
+    # Example annotations:
+    # annotations:
+    #   nginx.ingress.kubernetes.io/ssl-redirect: "true"
     hosts:
       - host: "pinpoint.localdev.me"  # CHANGE: Use your production domain
         paths:


### PR DESCRIPTION
## Summary

- Fix Web Ingress rendering to use `hosts[].paths[]` from values
- Add support for `ingressClassName`
- Add annotations and TLS rendering
- Support multiple hosts and paths

## Problem

Enabling `web.ingress.enabled` previously rendered empty `host` and `path`
fields because the template referenced `web.ingress.host` and
`web.ingress.path`, while values define `web.ingress.hosts[].paths[]`.

## Validation

- `helm lint .`
- `helm lint . --set global.metric.enabled=false`
- Rendered default and classic profiles
- Rendered multiple Ingress hosts with different path types
- Rendered TLS configuration