### PR TITLE
Fix/hbase persistence and ci

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -1,0 +1,27 @@
+name: Helm CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Lint and render chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.21.2
+
+      - name: Validate chart
+        run: bash scripts/helm-validate.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: Release Helm chart
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+concurrency:
+  group: helm-chart-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Package and publish chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.21.2
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Validate chart
+        run: bash scripts/helm-validate.sh
+
+      - name: Package chart
+        run: |
+          mkdir -p .cr-release-packages
+          helm package . --destination .cr-release-packages
+
+      - name: Publish GitHub release and Pages index
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          skip_packaging: true
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,27 @@
-#Chart
-**/Chart.lock
-**/charts/*.tgz
+# Helm build and release artifacts
+charts/
+*.tgz
+*.prov
 
-#Docker
+# Graph analysis artifacts
+graphify-out/
+.graphify_*.json
+
+# Local configuration and secrets
+.env
+.env.*
+!.env.example
+!.env.template
+/values.local.yaml
+/values.*.local.yaml
+/secrets*.yaml
+
+# Editor and operating-system files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# Docker artifacts
 docker-compose*

--- a/.helmignore
+++ b/.helmignore
@@ -6,10 +6,26 @@ docs/
 # Unnecessary system and IDE files
 .git/
 .gitignore
+.github/
 .idea/
 .vscode/
 .DS_Store
+graphify-out/
+scripts/
+.cr-index/
+.cr-release-packages/
+
+# Local configuration and generated release artifacts
+.env
+.env.*
+values.local.yaml
+values.*.local.yaml
+secrets*.yaml
+*.prov
+Dockerfile
+docker-compose*
 
 # To lighten the package, documentation files (Optional but recommended)
 README.md
+RELEASING.md
 LICENSE

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: zookeeper
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.8.7
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.0.3
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 22.0.7
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 32.4.3
+- name: pinot
+  repository: https://raw.githubusercontent.com/apache/pinot/master/helm
+  version: 0.3.4
+digest: sha256:705fcaf4dd48ad333fd830e6419f4b537ba332770cbbd349ee6bb17bef240c1b
+generated: "2026-08-05T23:51:04.430349372+03:00"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pinpoint Helm Chart
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.3](https://img.shields.io/badge/AppVersion-3.0.3-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.3](https://img.shields.io/badge/AppVersion-3.0.3-informational?style=flat-square)
 
 A Helm chart for deploying Pinpoint APM on Kubernetes.
 
@@ -10,13 +10,16 @@ This chart bootstraps a [Pinpoint APM](https://pinpoint-apm.github.io/pinpoint/)
 
 ## Installing the Chart
 
-To install the chart with the release name `pinpoint`:
+Add the Pinpoint chart repository and install the chart with the release name `pinpoint`:
 
 ```bash
-git clone https://github.com/pinpoint-apm/pinpoint-kubernetes.git
-cd pinpoint-kubernetes
-helm dependency update
+helm repo add pinpoint https://pinpoint-apm.github.io/pinpoint-kubernetes
+helm repo update
+helm install pinpoint pinpoint/pinpoint -n pinpoint --create-namespace
 ```
+
+To install directly from source instead, clone the repository, run
+`helm dependency build`, and use `helm install pinpoint .`.
 
 ### Deployment modes
 
@@ -24,13 +27,13 @@ This chart supports two deployment modes:
 
 **Metric Profile (default):**
 ```bash
-helm install pinpoint . -n pinpoint --create-namespace
+helm install pinpoint pinpoint/pinpoint -n pinpoint --create-namespace
 ```
 Deploys Kafka, Pinot, and Telegraf for advanced metrics collection.
 
 **Classic Mode:**
 ```bash
-helm install pinpoint . -n pinpoint --create-namespace --set global.metric.enabled=false
+helm install pinpoint pinpoint/pinpoint -n pinpoint --create-namespace --set global.metric.enabled=false
 ```
 Deploys Batch and Flink modules for traditional APM processing.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,29 @@
+# Releasing the Helm chart
+
+The release workflow packages the chart, creates a GitHub release, and updates
+the Helm repository index on the `gh-pages` branch.
+
+## One-time repository setup
+
+1. Create a `gh-pages` branch in the GitHub repository.
+2. In **Settings > Pages**, select **Deploy from a branch**, then choose the
+   `gh-pages` branch and the repository root.
+3. Ensure GitHub Actions is allowed to use a read/write `GITHUB_TOKEN` for the
+   repository.
+
+## Publish a chart version
+
+1. Update `version` in `Chart.yaml` according to semantic versioning. Update
+   `appVersion` only when the Pinpoint application version changes.
+2. Update the version badge in `README.md`.
+3. Open and merge a pull request into `master`.
+4. Verify that the **Release Helm chart** workflow created the GitHub release
+   and updated `gh-pages/index.yaml`.
+
+The chart can then be installed from the published repository:
+
+```bash
+helm repo add pinpoint https://pinpoint-apm.github.io/pinpoint-kubernetes
+helm repo update
+helm install pinpoint pinpoint/pinpoint -n pinpoint --create-namespace
+```

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+chart_dir="${1:-.}"
+render_dir="$(mktemp -d)"
+trap 'rm -rf "${render_dir}"' EXIT
+
+helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
+helm repo add pinot https://raw.githubusercontent.com/apache/pinot/master/helm --force-update
+helm dependency build "${chart_dir}"
+
+helm lint "${chart_dir}"
+helm lint "${chart_dir}" --set global.metric.enabled=false
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint > "${render_dir}/metric.yaml"
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --set global.metric.enabled=false > "${render_dir}/classic.yaml"
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --show-only templates/web.yaml \
+  --set web.ingress.enabled=true > "${render_dir}/web-ingress.yaml"
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --show-only templates/hbase.yaml > "${render_dir}/hbase-persistent.yaml"
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --show-only templates/hbase.yaml \
+  --set hbase.persistence.enabled=false > "${render_dir}/hbase-ephemeral.yaml"
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --show-only templates/hbase.yaml \
+  --set hbase.persistence.storageClass=fast-ssd > "${render_dir}/hbase-storage-class.yaml"
+
+grep -q 'volumeClaimTemplates:' "${render_dir}/hbase-persistent.yaml"
+grep -q 'host: "pinpoint.localdev.me"' "${render_dir}/web-ingress.yaml"
+grep -q 'path: "/"' "${render_dir}/web-ingress.yaml"
+
+if grep -q 'volumeClaimTemplates:' "${render_dir}/hbase-ephemeral.yaml"; then
+  echo "HBase ephemeral render unexpectedly contains volumeClaimTemplates" >&2
+  exit 1
+fi
+
+grep -q 'emptyDir: {}' "${render_dir}/hbase-ephemeral.yaml"
+grep -q 'storageClassName: "fast-ssd"' "${render_dir}/hbase-storage-class.yaml"
+
+echo "Helm lint and render validation passed."

--- a/templates/hbase.yaml
+++ b/templates/hbase.yaml
@@ -31,6 +31,10 @@ spec:
           configMap:
             name: {{ include "pinpoint.fullname" . }}-hbase-config
             defaultMode: 0755
+        {{- if not .Values.hbase.persistence.enabled }}
+        - name: hbase-data
+          emptyDir: {}
+        {{- end }}
       containers:
         - name: hbase
           image: "{{ .Values.hbase.image.repository }}:{{ .Values.hbase.image.tag | default .Values.global.pinpointVersion }}"
@@ -68,6 +72,7 @@ spec:
             {{- toYaml .Values.hbase.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.hbase.resources | nindent 12 }}
+  {{- if .Values.hbase.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: hbase-data
@@ -76,9 +81,10 @@ spec:
         resources:
           requests:
             storage: {{ .Values.hbase.persistence.size }}
-        {{- if .Values.hbase.persistence.storageClassName }}
-        storageClassName: {{ .Values.hbase.persistence.storageClassName }}
+        {{- with .Values.hbase.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
         {{- end }}
+  {{- end }}
 {{- end }}
 ---
 {{- if .Values.hbase.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -114,7 +114,7 @@ hbase:
   persistence:
     enabled: true
     size: 10Gi  # PRODUCTION: Increase based on data retention requirements (50Gi+ recommended)
-    # storageClass: "fast-ssd"  # Use high-performance storage class
+    storageClass: ""  # Set to a high-performance StorageClass, e.g. "fast-ssd"
   config:
     # External ZooKeeper recommended for production
     managesZk: false  # Uses external ZooKeeper cluster


### PR DESCRIPTION
## Summary

- honor `hbase.persistence.enabled`
  - use a PVC when persistence is enabled
  - use `emptyDir` when persistence is disabled
- render `hbase.persistence.storageClass` correctly
- commit `Chart.lock` for reproducible dependency resolution
- add Helm lint and render validation for:
  - metric mode
  - classic mode
  - Web Ingress
  - HBase persistent and ephemeral configurations
  - custom HBase StorageClass
- add GitHub Actions automation for:
  - pull request validation
  - Helm chart packaging
  - GitHub Releases
  - GitHub Pages Helm repository index
- document the release process and `helm repo add` installation
- exclude generated dependencies, packages, local secrets, and analysis artifacts

## Testing

```bash
bash scripts/helm-validate.sh