### PR TITLE
feat: support external Redis and Kafka

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Chart.lock
+++ b/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: pinot
   repository: https://raw.githubusercontent.com/apache/pinot/master/helm
   version: 0.3.4
-digest: sha256:705fcaf4dd48ad333fd830e6419f4b537ba332770cbbd349ee6bb17bef240c1b
-generated: "2026-08-05T23:51:04.430349372+03:00"
+digest: sha256:bc49c54e7f64d6ca271941a0bc7a2223ba3ba8bd74d77536087ee2dfce20387e
+generated: "2026-08-06T18:27:30.428679103+03:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pinpoint
 description: A Helm chart for deploying Pinpoint APM (Application Performance Management) on Kubernetes.
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: "3.0.3"
 
 keywords:
@@ -39,11 +39,11 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled
 
-  # CORRECT: Condition points directly to the boolean value in values.yaml
+  # kafka.enabled overrides the metric-mode default when explicitly provided.
   - name: kafka
     version: "32.4.3"
     repository: "https://charts.bitnami.com/bitnami"
-    condition: global.metric.enabled
+    condition: kafka.enabled,global.metric.enabled
 
   # CORRECT: Condition points directly to the boolean value in values.yaml
   - name: pinot

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pinpoint Helm Chart
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.3](https://img.shields.io/badge/AppVersion-3.0.3-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.3](https://img.shields.io/badge/AppVersion-3.0.3-informational?style=flat-square)
 
 A Helm chart for deploying Pinpoint APM on Kubernetes.
 
@@ -39,6 +39,37 @@ Deploys Batch and Flink modules for traditional APM processing.
 
 > **Note:** You may see warnings about `SessionAffinity is ignored for headless services`. These are harmless warnings and do not affect functionality.
 
+### External Redis and Kafka
+
+The bundled Redis and Kafka dependencies can be disabled independently. The
+following example uses an existing Redis Secret and assumes Kafka topics are
+managed outside this Helm release:
+
+```yaml
+global:
+  redis:
+    host: redis.example.internal
+    port: 6380
+    username: pinpoint
+    passwordSecret:
+      name: pinpoint-redis-credentials
+      key: password
+  kafka:
+    bootstrapServers: kafka-0.example.internal:9092,kafka-1.example.internal:9092
+    createTopics: false
+
+redis:
+  enabled: false
+
+kafka:
+  enabled: false
+```
+
+Use `global.redis.password` instead of `passwordSecret` only when storing a
+plain-text password in Helm values is acceptable. When
+`global.kafka.createTopics=true`, the chart's Kafka initialization job creates
+the required Pinpoint topics on the configured external brokers.
+
 ## Parameters
 
 ### Global parameters
@@ -55,6 +86,16 @@ Deploys Batch and Flink modules for traditional APM processing.
 | `global.datasource.passwordSecret.name` | Secret name containing password | `""` |
 | `global.datasource.passwordSecret.key` | Key in the Secret containing the password | `""` |
 | `global.datasource.password` | Database password (Not RECOMMENDED for production)<br/>- Defaults to the MySQL password from the chart dependency | `""` |
+| `global.redis.host` | External Redis hostname; required when `redis.enabled=false` | `""` |
+| `global.redis.port` | External Redis port | `6379` |
+| `global.redis.username` | External Redis username | `""` |
+| `global.redis.passwordSecret.name` | Secret containing the external Redis password | `""` |
+| `global.redis.passwordSecret.key` | Password key in the external Redis Secret | `""` |
+| `global.redis.password` | Plain-text external Redis password (not recommended) | `""` |
+| `global.kafka.bootstrapServers` | External Kafka bootstrap servers; required when `kafka.enabled=false` | `""` |
+| `global.kafka.createTopics` | Run the Kafka topic initialization job | `true` |
+| `redis.enabled` | Deploy the bundled Redis dependency | `true` |
+| `kafka.enabled` | Optional override for bundled Kafka; otherwise inherits `global.metric.enabled` | unset |
 
 ## Accessing Pinpoint
 

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -17,6 +17,34 @@ helm template pinpoint "${chart_dir}" --namespace pinpoint > "${render_dir}/metr
 helm template pinpoint "${chart_dir}" --namespace pinpoint \
   --set global.metric.enabled=false > "${render_dir}/classic.yaml"
 
+helm lint "${chart_dir}" \
+  --set redis.enabled=false \
+  --set global.redis.host=redis.external.example \
+  --set global.redis.port=6380 \
+  --set global.redis.username=pinpoint \
+  --set global.redis.passwordSecret.name=external-redis \
+  --set global.redis.passwordSecret.key=password \
+  --set kafka.enabled=false \
+  --set global.kafka.bootstrapServers=kafka.external.example:9092 \
+  --set global.kafka.createTopics=false
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --set redis.enabled=false \
+  --set global.redis.host=redis.external.example \
+  --set global.redis.port=6380 \
+  --set global.redis.username=pinpoint \
+  --set global.redis.passwordSecret.name=external-redis \
+  --set global.redis.passwordSecret.key=password \
+  --set kafka.enabled=false \
+  --set global.kafka.bootstrapServers=kafka.external.example:9092 \
+  --set global.kafka.createTopics=false > "${render_dir}/external-services.yaml"
+
+helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --show-only templates/init-job-kafka.yaml \
+  --set kafka.enabled=false \
+  --set global.kafka.bootstrapServers=kafka.external.example:9092 \
+  > "${render_dir}/external-kafka-init.yaml"
+
 helm template pinpoint "${chart_dir}" --namespace pinpoint \
   --show-only templates/web.yaml \
   --set web.ingress.enabled=true > "${render_dir}/web-ingress.yaml"
@@ -43,5 +71,53 @@ fi
 
 grep -q 'emptyDir: {}' "${render_dir}/hbase-ephemeral.yaml"
 grep -q 'storageClassName: "fast-ssd"' "${render_dir}/hbase-storage-class.yaml"
+
+grep -q 'value: "redis.external.example"' "${render_dir}/external-services.yaml"
+grep -q 'value: "6380"' "${render_dir}/external-services.yaml"
+grep -q 'value: "pinpoint"' "${render_dir}/external-services.yaml"
+grep -q 'name: "external-redis"' "${render_dir}/external-services.yaml"
+grep -q 'key: "password"' "${render_dir}/external-services.yaml"
+grep -q 'value: "kafka.external.example:9092"' "${render_dir}/external-services.yaml"
+grep -q 'name: pinpoint-kafka-init' "${render_dir}/external-kafka-init.yaml"
+grep -q 'value: "kafka.external.example:9092"' "${render_dir}/external-kafka-init.yaml"
+
+if grep -q '# Source: pinpoint/charts/redis/' "${render_dir}/external-services.yaml"; then
+  echo "External-services render unexpectedly contains bundled Redis resources" >&2
+  exit 1
+fi
+
+if grep -q '# Source: pinpoint/charts/kafka/' "${render_dir}/external-services.yaml"; then
+  echo "External-services render unexpectedly contains bundled Kafka resources" >&2
+  exit 1
+fi
+
+if grep -q 'name: pinpoint-kafka-init' "${render_dir}/external-services.yaml"; then
+  echo "External-services render unexpectedly contains the Kafka init job" >&2
+  exit 1
+fi
+
+if helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --set redis.enabled=false > "${render_dir}/invalid-external-redis.yaml" 2>&1; then
+  echo "Missing external Redis host unexpectedly rendered successfully" >&2
+  exit 1
+fi
+
+if helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --set kafka.enabled=false > "${render_dir}/invalid-external-kafka.yaml" 2>&1; then
+  echo "Missing external Kafka bootstrap servers unexpectedly rendered successfully" >&2
+  exit 1
+fi
+
+if helm template pinpoint "${chart_dir}" --namespace pinpoint \
+  --set global.metric.enabled=false \
+  --set redis.enabled=false \
+  --set global.redis.host=redis.external.example \
+  --set global.redis.password=inline-password \
+  --set global.redis.passwordSecret.name=external-redis \
+  --set global.redis.passwordSecret.key=password \
+  > "${render_dir}/invalid-redis-auth.yaml" 2>&1; then
+  echo "Conflicting external Redis authentication unexpectedly rendered successfully" >&2
+  exit 1
+fi
 
 echo "Helm lint and render validation passed."

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -58,7 +58,12 @@ Pinpoint has been successfully deployed.
 
 3. Checking the Installation Status:
 {{- if .Values.global.metric.enabled }}
-   The "metric" profile is enabled. You should see pods for Kafka and Pinot running.
+   The "metric" profile is enabled. You should see Pinot pods running.
+{{- if and (hasKey .Values.kafka "enabled") (not .Values.kafka.enabled) }}
+   Kafka endpoint: {{ include "pinpoint.kafka.bootstrapServers" . }} (external)
+{{- else }}
+   You should also see the bundled Kafka pods running.
+{{- end }}
 {{- else }}
    The "metric" profile is disabled. Kafka and Pinot are not deployed.
    To use URI statistics, OTLP metrics, and exception traces,

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -134,3 +134,84 @@ valueFrom:
 {{- fail "global.datasource.password or global.datasource.passwordSecret is required when mysql.enabled is false" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Redis host shared by Web and Collector.
+*/}}
+{{- define "pinpoint.redis.host" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s-redis-master" .Release.Name -}}
+{{- else -}}
+{{- required "global.redis.host is required when redis.enabled is false" .Values.global.redis.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis port shared by Web and Collector.
+*/}}
+{{- define "pinpoint.redis.port" -}}
+{{- if .Values.redis.enabled -}}
+6379
+{{- else -}}
+{{- required "global.redis.port is required when redis.enabled is false" .Values.global.redis.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis username shared by Web and Collector.
+*/}}
+{{- define "pinpoint.redis.username" -}}
+{{- if .Values.redis.enabled -}}
+{{- "" -}}
+{{- else -}}
+{{- .Values.global.redis.username -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis password value or Secret reference shared by Web and Collector.
+*/}}
+{{- define "pinpoint.redis.password" -}}
+{{- if .Values.redis.enabled -}}
+{{- if .Values.redis.auth.enabled -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ default (printf "%s-redis" .Release.Name) .Values.redis.auth.existingSecret | quote }}
+    key: {{ default "redis-password" .Values.redis.auth.existingSecretPasswordKey | quote }}
+{{- else -}}
+value: ""
+{{- end -}}
+{{- else -}}
+{{- $secret := .Values.global.redis.passwordSecret -}}
+{{- if or $secret.name $secret.key -}}
+{{- if .Values.global.redis.password -}}
+{{- fail "Configuration conflict: global.redis.password and global.redis.passwordSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if not $secret.name -}}
+{{- fail "global.redis.passwordSecret.name is required when passwordSecret.key is provided" -}}
+{{- end -}}
+{{- if not $secret.key -}}
+{{- fail "global.redis.passwordSecret.key is required when passwordSecret.name is provided" -}}
+{{- end -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ $secret.name | quote }}
+    key: {{ $secret.key | quote }}
+{{- else -}}
+value: {{ .Values.global.redis.password | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Kafka bootstrap servers shared by Collector and initialization jobs.
+*/}}
+{{- define "pinpoint.kafka.bootstrapServers" -}}
+{{- if .Values.global.kafka.bootstrapServers -}}
+{{- .Values.global.kafka.bootstrapServers -}}
+{{- else if and (hasKey .Values.kafka "enabled") (not .Values.kafka.enabled) -}}
+{{- fail "global.kafka.bootstrapServers is required when kafka.enabled is false" -}}
+{{- else -}}
+{{- printf "%s-kafka:9092" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/templates/collector.yaml
+++ b/templates/collector.yaml
@@ -39,11 +39,40 @@ spec:
               echo "HBase is ready!"
         {{- end }}
 
+        - name: wait-for-redis
+          image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
+          env:
+            - name: REDIS_HOST
+              value: {{ include "pinpoint.redis.host" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "pinpoint.redis.port" . | quote }}
+          command:
+            - 'sh'
+            - '-c'
+            - |
+              until nc -z -w3 "$REDIS_HOST" "$REDIS_PORT"; do
+                echo "Collector is waiting for Redis..."
+                sleep 2
+              done
+
         {{- if .Values.global.metric.enabled }}
         # Wait for Kafka only when metric profile is enabled.
         - name: wait-for-kafka
           image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
-          command: ['sh', '-c', 'until nc -z -w3 {{ .Release.Name }}-kafka 9092; do echo "Collector is waiting for Kafka..."; sleep 2; done;']
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
+          command:
+            - 'sh'
+            - '-c'
+            - |
+              KAFKA_ENDPOINT="${KAFKA_BOOTSTRAP_SERVERS%%,*}"
+              KAFKA_HOST="${KAFKA_ENDPOINT%:*}"
+              KAFKA_PORT="${KAFKA_ENDPOINT##*:}"
+              until nc -z -w3 "$KAFKA_HOST" "$KAFKA_PORT"; do
+                echo "Collector is waiting for Kafka..."
+                sleep 2
+              done
 
         # Wait for Pinot Controller only when metric profile is enabled.
         - name: wait-for-pinot-controller
@@ -105,9 +134,9 @@ spec:
             # Add Kafka and Pinot configurations only when metric profile is active
             {{- if .Values.global.metric.enabled }}
             - name: PINPOINT_METRIC_KAFKA_BOOTSTRAP_SERVERS
-              value: "{{ .Release.Name }}-kafka:9092"
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: "{{ .Release.Name }}-kafka:9092"
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
             - name: SPRING_PINOTDATASOURCE_PINOT_JDBCURL
               value: "jdbc:pinot://{{ .Release.Name }}-pinot-controller:9000"
             - name: PINPOINT_PINOT_JDBC_URL
@@ -120,24 +149,14 @@ spec:
             - name: MANAGEMENT_METRICS_EXPORT_OTLP_ENABLED
               value: "false"
             # Redis Connection Settings
-            {{- if .Values.redis.enabled }}
             - name: SPRING_DATA_REDIS_HOST
-              value: "{{ .Release.Name }}-redis-master"
+              value: {{ include "pinpoint.redis.host" . | quote }}
             - name: SPRING_DATA_REDIS_PORT
-              value: "6379"
+              value: {{ include "pinpoint.redis.port" . | quote }}
             - name: SPRING_DATA_REDIS_USERNAME
-              value: ""
-            {{- if .Values.redis.auth.enabled }}
+              value: {{ include "pinpoint.redis.username" . | quote }}
             - name: SPRING_DATA_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-redis"
-                  key: redis-password
-            {{- else }}
-            - name: SPRING_DATA_REDIS_PASSWORD
-              value: ""
-            {{- end }}
-            {{- end }}
+              {{ include "pinpoint.redis.password" . | nindent 14 }}
 
             # Additional Collector Configuration (matching Docker Compose)
             {{- if not .Values.global.metric.enabled }}

--- a/templates/init-job-kafka.yaml
+++ b/templates/init-job-kafka.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.metric.enabled }}
+{{- if and .Values.global.metric.enabled .Values.global.kafka.createTopics }}
 # Kafka Topics Initialization Job
 apiVersion: batch/v1
 kind: Job
@@ -28,12 +28,18 @@ spec:
       initContainers:
         - name: wait-for-kafka
           image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
           command:
             - 'sh'
             - '-c'
             - |
               echo "Waiting for Kafka to be ready..."
-              until nc -z -w3 {{ .Release.Name }}-kafka 9092; do
+              KAFKA_ENDPOINT="${KAFKA_BOOTSTRAP_SERVERS%%,*}"
+              KAFKA_HOST="${KAFKA_ENDPOINT%:*}"
+              KAFKA_PORT="${KAFKA_ENDPOINT##*:}"
+              until nc -z -w3 "$KAFKA_HOST" "$KAFKA_PORT"; do
                 echo "Kafka init job waiting for Kafka..."
                 sleep 5
               done
@@ -46,7 +52,7 @@ spec:
             - '-c'
             - |
               echo "Setting up Kafka topics..."
-              BOOTSTRAP_SERVER="{{ .Release.Name }}-kafka:9092"
+              BOOTSTRAP_SERVER="$KAFKA_BOOTSTRAP_SERVERS"
 
               # Wait for Kafka to be ready
               until kafka-topics --list --bootstrap-server "$BOOTSTRAP_SERVER" >/dev/null 2>&1; do
@@ -75,5 +81,5 @@ spec:
               echo "Topics created successfully!"
           env:
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: "{{ .Release.Name }}-kafka:9092"
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
 {{- end }}

--- a/templates/init-job-pinot.yaml
+++ b/templates/init-job-pinot.yaml
@@ -28,6 +28,9 @@ spec:
       initContainers:
         - name: wait-for-pinot
           image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
           command:
             - 'sh'
             - '-c'
@@ -47,7 +50,10 @@ spec:
               echo "Pinot Broker is ready!"
 
               echo "Waiting for Kafka to be ready..."
-              until nc -z -w3 {{ .Release.Name }}-kafka 9092; do
+              KAFKA_ENDPOINT="${KAFKA_BOOTSTRAP_SERVERS%%,*}"
+              KAFKA_HOST="${KAFKA_ENDPOINT%:*}"
+              KAFKA_PORT="${KAFKA_ENDPOINT##*:}"
+              until nc -z -w3 "$KAFKA_HOST" "$KAFKA_PORT"; do
                 echo "Pinot init job is waiting for Kafka..."
                 sleep 5
               done
@@ -103,7 +109,7 @@ spec:
               echo "All files validated successfully"
 
               # Update Kafka bootstrap servers in table configurations
-              sed -i 's/localhost:19092/{{ .Release.Name }}-kafka:9092/g' *.json
+              sed -i "s|localhost:19092|${KAFKA_BOOTSTRAP_SERVERS}|g" *.json
               sed -i 's/.*replicasPerPartition.*/    "replicasPerPartition": "1",/g' *.json
 
               # Check if tables already exist
@@ -138,6 +144,8 @@ spec:
 
               echo "All tables created successfully!"
           env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ include "pinpoint.kafka.bootstrapServers" . | quote }}
             - name: PINOT_CONTROLLER_HOST
               value: "{{ .Release.Name }}-pinot-controller"
             - name: PINOT_CONTROLLER_PORT

--- a/templates/web.yaml
+++ b/templates/web.yaml
@@ -49,11 +49,21 @@ spec:
           command: ['sh', '-c', 'until nc -z -w3 {{ include "pinpoint.fullname" . }}-hbase 16010; do echo "Web is waiting for HBase..."; sleep 2; done;']
         {{- end }}
 
-        {{- if .Values.redis.enabled }}
         - name: wait-for-redis
           image: {{ include "pinpoint.imageRegistry" . }}busybox:1.36
-          command: ['sh', '-c', 'until nc -z -w3 {{ .Release.Name }}-redis-master 6379; do echo "Web is waiting for Redis..."; sleep 2; done;']
-        {{- end }}
+          env:
+            - name: REDIS_HOST
+              value: {{ include "pinpoint.redis.host" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "pinpoint.redis.port" . | quote }}
+          command:
+            - 'sh'
+            - '-c'
+            - |
+              until nc -z -w3 "$REDIS_HOST" "$REDIS_PORT"; do
+                echo "Web is waiting for Redis..."
+                sleep 2
+              done
 
         {{- if .Values.global.metric.enabled }}
         # Wait for the Pinot Controller only when metric profile is enabled.
@@ -127,24 +137,14 @@ spec:
               value: ""
             {{- end }}
 
-            {{- if .Values.redis.enabled }}
             - name: SPRING_DATA_REDIS_HOST
-              value: "{{ .Release.Name }}-redis-master"
+              value: {{ include "pinpoint.redis.host" . | quote }}
             - name: SPRING_DATA_REDIS_PORT
-              value: "6379"
+              value: {{ include "pinpoint.redis.port" . | quote }}
             - name: SPRING_DATA_REDIS_USERNAME
-              value: ""
-            {{- if .Values.redis.auth.enabled }}
+              value: {{ include "pinpoint.redis.username" . | quote }}
             - name: SPRING_DATA_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-redis"
-                  key: redis-password
-            {{- else }}
-            - name: SPRING_DATA_REDIS_PASSWORD
-              value: ""
-            {{- end }}
-            {{- end }}
+              {{ include "pinpoint.redis.password" . | nindent 14 }}
 
             # Additional Web Configuration (matching Docker Compose)
             - name: WEB_SERVER_PORT

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,23 @@ global:
   # metric.enabled: false = Classic stack (Batch + Flink + traditional processing)
   metric:
     enabled: true  # DEFAULT: Modern mode for new deployments
+  # Shared Redis connection configuration for Web and Collector.
+  # Used when redis.enabled=false. Password is optional, and passwordSecret is
+  # mutually exclusive with password.
+  redis:
+    host: ""
+    port: 6379
+    username: ""
+    passwordSecret:
+      name: ""
+      key: ""
+    password: ""
+  # Shared Kafka connection configuration for Collector and initialization jobs.
+  kafka:
+    # Required when kafka.enabled=false. Multiple brokers can be comma-separated.
+    bootstrapServers: ""
+    # Disable when topics are managed outside this Helm release.
+    createTopics: true
   # Global Datasource Configuration (Shared by Web and Batch)
   # This configuration controls how Web and Batch components connect to the MySQL database.
   datasource:
@@ -405,8 +422,10 @@ redis:
     #     cpu: 500m
     #     memory: 1Gi
 
-# Kafka - Message streaming platform (only deployed when global.metric.enabled: true)
-# Controlled by global.metric.enabled in Chart.yaml
+# Kafka - Message streaming platform (deployed in metric mode by default)
+# To use external Kafka, set kafka.enabled=false and configure
+# global.kafka.bootstrapServers. `enabled` is intentionally omitted here so
+# global.metric.enabled remains the backward-compatible default condition.
 kafka:
   image:
     registry: docker.io


### PR DESCRIPTION
## Summary

- allow disabling the bundled Redis and Kafka dependencies independently
- add shared external Redis host, port, username, and password configuration
- support external Redis passwords through an existing Kubernetes Secret
- add shared Kafka bootstrap server configuration for Collector and initialization jobs
- allow Kafka topic creation to be disabled when topics are managed externally
- update Pinot table initialization to use the configured Kafka bootstrap servers
- preserve existing metric/classic behavior by falling back to `global.metric.enabled`
- add validation and render coverage for internal and external service configurations
- bump the chart version to `2.2.0`

## Testing

- `bash scripts/helm-validate.sh`
- default, classic, and external-service Helm lint
- default, classic, external Redis/Kafka, Ingress, and HBase render validation
- missing external endpoint and conflicting Redis authentication validation
- packaged chart rendering with external Redis and Kafka
- multiple Kafka bootstrap server rendering
- bundled Redis existing Secret rendering

Closes #43