### PR TITLE
fix(ci): bootstrap gh-pages before chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,16 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Ensure GitHub Pages branch exists
+        shell: bash
+        run: |
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            empty_tree=$(git mktree </dev/null)
+            bootstrap_commit=$(git commit-tree "$empty_tree" -m "chore: initialize Helm chart repository")
+            git push origin "$bootstrap_commit:refs/heads/gh-pages"
+          fi
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages
+
       - name: Validate chart
         run: bash scripts/helm-validate.sh
 
@@ -46,5 +56,6 @@ jobs:
         with:
           skip_packaging: true
           skip_existing: true
+          pages_branch: gh-pages
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

- create the `gh-pages` branch automatically when it does not exist
- fetch the branch as `origin/gh-pages` before running chart-releaser
- explicitly configure `gh-pages` as the chart publishing branch
- keep subsequent release runs idempotent

## Problem

The initial chart release workflow failed because `helm/chart-releaser-action` expects the `gh-pages` branch to exist:

```text
fatal: invalid reference: origin/gh-pages